### PR TITLE
Follow Jekyll change on v3

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -2,7 +2,9 @@
 <html lang="{{ page.language }}">
   <head>
     {% capture title %}{% if page.title %}{{ page.title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}{% endcapture %}
+    {% unless page.categories contains "news" %}
     {% capture relative_path %}{{ page.url | remove_first: page.path_prefix | remove: "index.html" }}{% endcapture %}
+    {% endunless %}
 
     {% if page.description %}
       {% assign description = page.description %}


### PR DESCRIPTION
From v3, Jekyll seems not to provide `page.path_prefix` in some type of pages and reference to it raise errors.
