### PR TITLE
Fix link from reference to tutorial

### DIFF
--- a/reference/1.1.1/plugin/index.md
+++ b/reference/1.1.1/plugin/index.md
@@ -4,7 +4,7 @@ layout: en
 ---
 
 Droonga Engine has different API sets for plugins, on each phase.
-See also the [plugin development tutorial](../../tutorial/plugin-development/).
+See also the [plugin development tutorial](../../../tutorial/plugin-development/).
 
  * [API set for the adaption phase](adapter/)
  * [API set for the handling phase](handler/)


### PR DESCRIPTION
I found a broken link in http://droonga.org/reference/1.1.1/plugin/ .
I fixed only a file that is the newest version because I don't know what I should fix old versions.
